### PR TITLE
override Asp.Net Core default file upload limit

### DIFF
--- a/SimpleUpload/Controllers/HomeController.cs
+++ b/SimpleUpload/Controllers/HomeController.cs
@@ -27,6 +27,11 @@ namespace SimpleUpload.Controllers
         }
 
         [HttpPost("UploadFiles")]
+        //OPTION A: Disables Asp.Net Core's default upload size limit
+        [DisableRequestSizeLimit]
+        //OPTION B: Uncomment to set a specified upload file limit
+        //[RequestSizeLimit(40000000)] 
+
         public async Task<IActionResult> Post(List<IFormFile> files)
         {
             var uploadSuccess = false;


### PR DESCRIPTION
Controlling the file upload limit in Asp.Net core by completely removing the limit or  setting your preferred file upload limit